### PR TITLE
Add study timer with navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,25 @@
 </head>
 <body>
   <!-- Sticky Page Header -->
-  <nav class="navbar navbar-light bg-light mb-4">
-    <div class="container-fluid justify-content-center">
-      <span class="navbar-brand mb-0 h1">DP1 Exam Assistant</span>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">DP1 Exam Assistant</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="#schedule">Exam Dates</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#timer">Timer</a>
+          </li>
+        </ul>
+      </div>
     </div>
   </nav>
-  <div class="container my-5">
+  <div class="container my-5" id="schedule">
     <!-- Pomodoro and Export Calendar card -->
     <div class="card p-3 mb-4" style="background-color: #f7fbff;">
       <div class="row align-items-center">
@@ -257,6 +270,33 @@
       </div>
     </div>
   </div>
+  </div>
+
+  <!-- end schedule container -->
+
+  <div class="container my-5" id="timer">
+    <div class="card p-4" style="background-color: #f7fbff;">
+      <h3 class="text-center mb-3">Study Timer</h3>
+      <div class="input-group mb-3">
+        <span class="input-group-text">Minutes</span>
+        <input type="number" class="form-control" id="timerMinutes" value="25" min="1">
+      </div>
+      <div class="d-flex justify-content-center mb-3">
+        <button class="btn btn-primary me-2" id="startBtn">Start</button>
+        <button class="btn btn-secondary me-2 d-none" id="pauseBtn">Pause</button>
+        <button class="btn btn-secondary me-2 d-none" id="resumeBtn">Resume</button>
+        <button class="btn btn-danger d-none" id="resetBtn">Reset</button>
+      </div>
+      <div class="progress mb-2">
+        <div id="timerProgress" class="progress-bar" role="progressbar" style="width:0%">0%</div>
+      </div>
+      <h4 class="text-center" id="timerDisplay">0m 00s</h4>
+    </div>
+  </div>
+
+  <footer class="text-center mt-5 mb-3 text-muted">
+    DP1 Exam Assistant © 2025
+  </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
@@ -438,9 +478,9 @@
       document.body.removeChild(link);
     }
     // Pomodoro timer
-    let pomodoroInterval;
+  let pomodoroInterval;
 
-    function startTimer(duration) {
+  function startTimer(duration) {
       clearInterval(pomodoroInterval);
       let timer = duration, minutes, seconds;
       const display = document.getElementById('pomodoroDisplay');
@@ -454,10 +494,68 @@
         }
       }, 1000);
     }
+
+  // Study timer with pause/resume and progress bar
+  let studyInterval;
+  let studyTotal = 0;
+  let studyRemaining = 0;
+
+  function updateStudyDisplay() {
+    const mins = Math.floor(studyRemaining / 60);
+    const secs = studyRemaining % 60;
+    const percent = studyTotal ? ((studyTotal - studyRemaining) / studyTotal) * 100 : 0;
+    document.getElementById('timerDisplay').textContent = `${mins}m ${secs.toString().padStart(2,'0')}s`;
+    const bar = document.getElementById('timerProgress');
+    bar.style.width = `${percent}%`;
+    bar.textContent = `${Math.floor(percent)}%`;
+  }
+
+  function tickStudy() {
+    if (studyRemaining <= 0) {
+      clearInterval(studyInterval);
+      document.getElementById('timerDisplay').textContent = "⏰ Time's up!";
+      document.getElementById('pauseBtn').classList.add('d-none');
+      document.getElementById('resumeBtn').classList.add('d-none');
+      return;
+    }
+    studyRemaining--;
+    updateStudyDisplay();
+  }
+
+  document.getElementById('startBtn').addEventListener('click', () => {
+    studyTotal = parseInt(document.getElementById('timerMinutes').value, 10) * 60;
+    if (!studyTotal) return;
+    studyRemaining = studyTotal;
+    updateStudyDisplay();
+    document.getElementById('startBtn').classList.add('d-none');
+    document.getElementById('pauseBtn').classList.remove('d-none');
+    document.getElementById('resetBtn').classList.remove('d-none');
+    studyInterval = setInterval(tickStudy, 1000);
+  });
+
+  document.getElementById('pauseBtn').addEventListener('click', () => {
+    clearInterval(studyInterval);
+    document.getElementById('pauseBtn').classList.add('d-none');
+    document.getElementById('resumeBtn').classList.remove('d-none');
+  });
+
+  document.getElementById('resumeBtn').addEventListener('click', () => {
+    document.getElementById('resumeBtn').classList.add('d-none');
+    document.getElementById('pauseBtn').classList.remove('d-none');
+    studyInterval = setInterval(tickStudy, 1000);
+  });
+
+  document.getElementById('resetBtn').addEventListener('click', () => {
+    clearInterval(studyInterval);
+    document.getElementById('startBtn').classList.remove('d-none');
+    document.getElementById('pauseBtn').classList.add('d-none');
+    document.getElementById('resumeBtn').classList.add('d-none');
+    document.getElementById('resetBtn').classList.add('d-none');
+    studyRemaining = studyTotal;
+    updateStudyDisplay();
+    document.getElementById('timerProgress').style.width = '0%';
+  document.getElementById('timerProgress').textContent = '0%';
+});
   </script>
 </body>
 </html>
-  <!-- Footer -->
-  <footer class="text-center mt-5 mb-3 text-muted">
-    DP1 Exam Assistant © 2025
-  </footer>


### PR DESCRIPTION
## Summary
- create responsive navbar with Exam Dates and Timer links
- add study timer section with pause/resume and progress bar
- move footer inside body
- include JavaScript to drive new timer

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_684029683e648321a40587d074284bb7